### PR TITLE
Add development argument with Argparse

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,17 @@
 import os
 import discord
 from discord.ext import commands
+import argparse
+
+# Add an argument parser to handle production and development mode
+parser = argparse.ArgumentParser(description="Discord bot for the Discord server")
+parser.add_argument("--dev", action="store_true", help="Run the bot in development mode")
+args = parser.parse_args()
+
+if args.dev:
+    import dotenv
+    dotenv.load_dotenv()
+    
 
 bot = commands.Bot(command_prefix='cb ', intents=discord.Intents.all())
 
@@ -11,4 +22,4 @@ bot = commands.Bot(command_prefix='cb ', intents=discord.Intents.all())
 async def on_ready():
     print(f"Logged in as {bot.user}")
 
-bot.run(os.environ["DISCORD_TOKEN"])
+bot.run(os.environ.get("DISCORD_TOKEN"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 git+https://github.com/Rapptz/discord.py
+python-dotenv


### PR DESCRIPTION
This feature makes it easier to test a bot by checking for the `--dev` flag and loading the `.env` file if found.